### PR TITLE
Fix subtitle style syntax

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,7 +295,7 @@
       weight: '400',
       style: 'normal',
       color: 'transparent',
-      stroke: '2px var(--text)'
+      stroke: '2px var(--text)',
       text: 'Bioinformatician'
     },
     {


### PR DESCRIPTION
## Summary
- fix missing comma in subtitle style object

## Testing
- `htmlhint index.html` *(fails: command not found)*
- `tidy -errors index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846206bf6c0832c9cfc334156814e1e