### PR TITLE
Add animated math-themed decorative layer (sine tracks & orbit circles) to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,14 +43,78 @@
       inset: 0;
       /*  *Feel free to swap this data-URI for your own noise texture*  */
       background-image: url('data:image/svg+xml;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4/5+hHgAHggJ/qTJSwwAAAABJRU5ErkJggg==');
-      opacity: .15;
+      opacity: .12;
       pointer-events: none;
+      z-index: 3;
+    }
+
+
+    .math-scroll-art {
+      position: fixed;
+      inset: 0;
+      pointer-events: none;
+      z-index: 1;
+      overflow: hidden;
     }
 
     .container {
+      position: relative;
+      z-index: 1;
       max-width: 1200px;
       margin: 0 auto;
       padding: 2rem;
+    }
+
+    .sine-track {
+      position: absolute;
+      width: 220px;
+      height: 200vh;
+      top: -50vh;
+      opacity: .9;
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 140 800'%3E%3Cpath d='M70 0 C20 80 120 160 70 240 C20 320 120 400 70 480 C20 560 120 640 70 720 C20 760 90 800 70 800' stroke='%23C70039' stroke-width='3' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
+      background-repeat: repeat-y;
+      background-size: 100% 420px;
+      filter: drop-shadow(0 0 8px rgba(199, 0, 57, .45));
+      will-change: transform;
+    }
+
+    .sine-left { left: 0; }
+
+    .sine-right {
+      right: 0;
+      transform: scaleX(-1);
+      opacity: .75;
+    }
+
+    .orbit-circle {
+      position: absolute;
+      border-radius: 50%;
+      border: 3px solid rgba(199, 0, 57, .75);
+      box-shadow: 0 0 0 8px rgba(199, 0, 57, .1), 0 0 24px rgba(199, 0, 57, .35);
+      will-change: transform;
+    }
+
+    .orbit-one {
+      width: 180px;
+      height: 180px;
+      left: 4vw;
+      top: 12vh;
+    }
+
+    .orbit-two {
+      width: 130px;
+      height: 130px;
+      right: 5vw;
+      top: 60vh;
+      border-color: rgba(211, 211, 211, .8);
+    }
+
+
+
+    @media (prefers-reduced-motion: reduce) {
+      .sine-track, .orbit-circle {
+        transform: none !important;
+      }
     }
 
     /*  ░░░  HERO  ░░░  */
@@ -211,6 +275,12 @@
   </style>
 </head>
 <body>
+  <div class="math-scroll-art" aria-hidden="true">
+    <div class="sine-track sine-left"></div>
+    <div class="sine-track sine-right"></div>
+    <div class="orbit-circle orbit-one"></div>
+    <div class="orbit-circle orbit-two"></div>
+  </div>
   <div id="cursor-circle"></div>
   <div class="container">
 
@@ -344,6 +414,42 @@
   };
 
   applyStyle(subtitleStyles[idx]);
+
+  const artLayer = {
+    leftSine: document.querySelector('.sine-left'),
+    rightSine: document.querySelector('.sine-right'),
+    orbitOne: document.querySelector('.orbit-one'),
+    orbitTwo: document.querySelector('.orbit-two')
+  };
+
+  let scheduled = false;
+
+  const animateMathDecor = () => {
+    const y = window.scrollY;
+    const waveA = Math.sin(y * 0.01) * 22;
+    const waveB = Math.cos(y * 0.008) * 28;
+
+    artLayer.leftSine.style.transform = `translate3d(${waveA}px, ${-y * 0.22}px, 0)`;
+    artLayer.rightSine.style.transform = `translate3d(${waveB}px, ${-y * 0.28}px, 0) scaleX(-1)`;
+
+    const scaleOne = 1 + (Math.sin(y * 0.012) + 1) * 0.18;
+    const scaleTwo = 1 + (Math.cos(y * 0.011) + 1) * 0.2;
+
+    artLayer.orbitOne.style.transform = `translate3d(${Math.sin(y * 0.009) * 30}px, ${y * 0.12}px, 0) scale(${scaleOne})`;
+    artLayer.orbitTwo.style.transform = `translate3d(${Math.cos(y * 0.007) * -26}px, ${-y * 0.1}px, 0) scale(${scaleTwo})`;
+
+    scheduled = false;
+  };
+
+  window.addEventListener('scroll', () => {
+    if (!scheduled) {
+      requestAnimationFrame(animateMathDecor);
+      scheduled = true;
+    }
+  }, { passive: true });
+
+  animateMathDecor();
+
 
     setInterval(() => {
     idx = (idx + 1) % subtitleStyles.length;


### PR DESCRIPTION
### Motivation
- Introduce a subtle, math-inspired decorative layer that animates on scroll to enliven the hero/landing area while keeping interactive elements unaffected.
- Improve layering and z-index so the existing content and the noise overlay render correctly with the new art elements.

### Description
- Added a new `.math-scroll-art` container and four decorative elements (`.sine-track` left/right and `.orbit-circle` one/two) into the page DOM with `aria-hidden="true"` and `pointer-events: none` to avoid interfering with UX.
- Implemented CSS for the art layer including SVG-based repeating sine tracks, orbit circle styling, sizing/positioning, drop shadows, and `@media (prefers-reduced-motion: reduce)` to disable transforms for reduced-motion users.
- Adjusted existing layout z-index/positioning by making `.container` `position: relative` with `z-index: 1` and lowered the noise overlay opacity slightly from `.15` to `.12` while raising its `z-index` to `3` to refine stacking order.
- Added scroll-driven animation logic using `requestAnimationFrame` in `animateMathDecor` to translate and scale the decorative elements smoothly, and initialized the animation once on load.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11fbeb6f54832cad6b055305280dac)