### PR TITLE
Add scroll-synced decorative math art overlay (sine tracks & orbit circles)

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,14 +43,66 @@
       inset: 0;
       /*  *Feel free to swap this data-URI for your own noise texture*  */
       background-image: url('data:image/svg+xml;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4/5+hHgAHggJ/qTJSwwAAAABJRU5ErkJggg==');
-      opacity: .15;
+      opacity: .12;
       pointer-events: none;
+      z-index: 3;
+    }
+
+
+    .math-scroll-art {
+      position: fixed;
+      inset: 0;
+      pointer-events: none;
+      z-index: 2;
+      overflow: hidden;
     }
 
     .container {
+      position: relative;
+      z-index: 4;
       max-width: 1200px;
       margin: 0 auto;
       padding: 2rem;
+    }
+
+    .sine-track {
+      position: absolute;
+      width: clamp(170px, 20vw, 300px);
+      height: 260vh;
+      top: -80vh;
+      opacity: .98;
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 260 1100'%3E%3Cpath d='M130 0 C30 70 230 140 130 210 C30 280 230 350 130 420 C30 490 230 560 130 630 C30 700 230 770 130 840 C30 910 230 980 130 1050' stroke='%23C70039' stroke-width='5' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
+      background-repeat: repeat-y;
+      background-size: 100% 480px;
+      filter: drop-shadow(0 0 10px rgba(199, 0, 57, .5));
+      will-change: transform;
+    }
+
+    .sine-left { left: -46px; }
+
+    .sine-right {
+      right: -46px;
+      transform: scaleX(-1);
+      opacity: .82;
+    }
+
+    .orbit-circle {
+      position: absolute;
+      border-radius: 50%;
+      border: 3px solid rgba(255, 230, 230, .95);
+      box-shadow: 0 0 0 5px rgba(199, 0, 57, .08), 0 0 18px rgba(199, 0, 57, .3);
+      opacity: .92;
+      will-change: transform;
+    }
+
+    .orbit-one { width: 150px; height: 150px; }
+    .orbit-two { width: 122px; height: 122px; }
+    .orbit-three { width: 104px; height: 104px; }
+    .orbit-four { width: 86px; height: 86px; }
+    @media (prefers-reduced-motion: reduce) {
+      .sine-track, .orbit-circle {
+        transform: none !important;
+      }
     }
 
     /*  ░░░  HERO  ░░░  */
@@ -211,6 +263,14 @@
   </style>
 </head>
 <body>
+  <div class="math-scroll-art" aria-hidden="true">
+    <div class="sine-track sine-left"></div>
+    <div class="sine-track sine-right"></div>
+    <div class="orbit-circle orbit-one"></div>
+    <div class="orbit-circle orbit-two"></div>
+    <div class="orbit-circle orbit-three"></div>
+    <div class="orbit-circle orbit-four"></div>
+  </div>
   <div id="cursor-circle"></div>
   <div class="container">
 
@@ -344,6 +404,63 @@
   };
 
   applyStyle(subtitleStyles[idx]);
+
+  const artLayer = {
+    leftSine: document.querySelector('.sine-left'),
+    rightSine: document.querySelector('.sine-right'),
+    circles: [
+      document.querySelector('.orbit-one'),
+      document.querySelector('.orbit-two'),
+      document.querySelector('.orbit-three'),
+      document.querySelector('.orbit-four')
+    ]
+  };
+
+  let scheduled = false;
+
+  const animateMathDecor = () => {
+    const y = window.scrollY;
+    const amplitude = 90;
+    const wavelength = 260;
+    const verticalDrift = y * 0.38;
+
+    artLayer.leftSine.style.transform = `translate3d(0, ${-verticalDrift}px, 0)`;
+    artLayer.rightSine.style.transform = `translate3d(0, ${-verticalDrift}px, 0) scaleX(-1)`;
+
+    const anchors = [
+      { side: 'left', baseY: 16, r: 75 },
+      { side: 'left', baseY: 38, r: 61 },
+      { side: 'right', baseY: 24, r: 52 },
+      { side: 'right', baseY: 52, r: 43 }
+    ];
+
+    anchors.forEach((anchor, i) => {
+      const circle = artLayer.circles[i];
+      if (!circle) return;
+
+      const localY = (y * 0.55) + anchor.baseY * 10;
+      const waveOffset = Math.sin(localY / wavelength) * amplitude;
+      const sideSign = anchor.side === 'left' ? 1 : -1;
+      const railX = anchor.side === 'left' ? 42 : window.innerWidth - 42;
+      const tangentX = railX + (sideSign * waveOffset);
+      const centerX = tangentX + (sideSign * anchor.r);
+      const centerY = anchor.baseY + (localY * 0.18);
+
+      circle.style.transform = `translate3d(${centerX - anchor.r}px, ${centerY - anchor.r}px, 0)`;
+    });
+
+    scheduled = false;
+  };
+
+  window.addEventListener('scroll', () => {
+    if (!scheduled) {
+      requestAnimationFrame(animateMathDecor);
+      scheduled = true;
+    }
+  }, { passive: true });
+
+  animateMathDecor();
+
 
     setInterval(() => {
     idx = (idx + 1) % subtitleStyles.length;


### PR DESCRIPTION
### Motivation

- Add a subtle math-themed decorative layer (sine tracks and orbiting circles) to the page to enhance the hero visual and reinforce the bioinformatics/mathematics motif. 
- Ensure the decorative art sits behind interactive content by adjusting stacking context and reducing noise opacity for a less distracting background. 
- Keep animations performant and accessible by using `requestAnimationFrame` and honoring `prefers-reduced-motion`.

### Description

- Insert a new decorative overlay `div.math-scroll-art` (marked `aria-hidden="true"`) containing two `.sine-track` elements and four `.orbit-circle` elements in the page DOM. 
- Add CSS for `.math-scroll-art`, `.sine-track`, and `.orbit-circle` including an inline SVG background for sine tracks, drop-shadows, `will-change` hints, and z-index adjustments plus a `prefers-reduced-motion` media query; also tweak `body::before` opacity and set `.container` positioning/z-index. 
- Implement scroll-synced animation with a new `artLayer` object and `animateMathDecor` function that computes sinusoidal offsets and applies `transform` via `requestAnimationFrame`, with simple scheduling to avoid redundant frames.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11fbeb6f54832cad6b055305280dac)