### PR TITLE
Add math-themed scroll decorations (sine tracks + orbiting circles) with scroll animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,14 +43,74 @@
       inset: 0;
       /*  *Feel free to swap this data-URI for your own noise texture*  */
       background-image: url('data:image/svg+xml;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4/5+hHgAHggJ/qTJSwwAAAABJRU5ErkJggg==');
-      opacity: .15;
+      opacity: .12;
       pointer-events: none;
+      z-index: 3;
+    }
+
+
+    .math-scroll-art {
+      position: fixed;
+      inset: 0;
+      pointer-events: none;
+      z-index: 2;
+      overflow: hidden;
     }
 
     .container {
+      position: relative;
+      z-index: 4;
       max-width: 1200px;
       margin: 0 auto;
       padding: 2rem;
+    }
+
+    .sine-track {
+      position: absolute;
+      width: clamp(170px, 20vw, 300px);
+      height: 100%;
+      top: 0;
+      opacity: .98;
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 260 640'%3E%3Cpath d='M130 0 C50 40 50 120 130 160 C210 200 210 280 130 320 C50 360 50 440 130 480 C210 520 210 600 130 640' stroke='%23C70039' stroke-width='5' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
+      background-repeat: repeat-y;
+      background-size: 100% 320px;
+      filter: drop-shadow(0 0 10px rgba(199, 0, 57, .5));
+      will-change: transform;
+    }
+
+    .sine-left { left: -46px; }
+
+    .sine-right {
+      right: -46px;
+      transform: scaleX(-1);
+      opacity: .82;
+    }
+
+    .orbit-circle {
+      position: absolute;
+      border-radius: 50%;
+      border: 3px solid rgba(255, 230, 230, .95);
+      box-shadow: 0 0 0 5px rgba(199, 0, 57, .08), 0 0 18px rgba(199, 0, 57, .3);
+      opacity: .92;
+      will-change: transform;
+    }
+
+    .orbit-one { width: 150px; height: 150px; }
+    .orbit-two { width: 122px; height: 122px; }
+    .orbit-three { width: 104px; height: 104px; }
+    .orbit-four { width: 86px; height: 86px; }
+
+    .orbit-five { width: 74px; height: 74px; }
+    .orbit-six { width: 66px; height: 66px; }
+    .orbit-seven { width: 58px; height: 58px; }
+    .orbit-eight { width: 50px; height: 50px; }
+    .orbit-nine { width: 42px; height: 42px; }
+    .orbit-ten { width: 36px; height: 36px; }
+
+    @media (prefers-reduced-motion: reduce) {
+      .sine-track, .orbit-circle {
+        transform: none !important;
+      }
     }
 
     /*  ░░░  HERO  ░░░  */
@@ -211,6 +271,20 @@
   </style>
 </head>
 <body>
+  <div class="math-scroll-art" aria-hidden="true">
+    <div class="sine-track sine-left"></div>
+    <div class="sine-track sine-right"></div>
+    <div class="orbit-circle orbit-one"></div>
+    <div class="orbit-circle orbit-two"></div>
+    <div class="orbit-circle orbit-three"></div>
+    <div class="orbit-circle orbit-four"></div>
+    <div class="orbit-circle orbit-five"></div>
+    <div class="orbit-circle orbit-six"></div>
+    <div class="orbit-circle orbit-seven"></div>
+    <div class="orbit-circle orbit-eight"></div>
+    <div class="orbit-circle orbit-nine"></div>
+    <div class="orbit-circle orbit-ten"></div>
+  </div>
   <div id="cursor-circle"></div>
   <div class="container">
 
@@ -344,6 +418,75 @@
   };
 
   applyStyle(subtitleStyles[idx]);
+
+  const artLayer = {
+    leftSine: document.querySelector('.sine-left'),
+    rightSine: document.querySelector('.sine-right'),
+    circles: [
+      document.querySelector('.orbit-one'),
+      document.querySelector('.orbit-two'),
+      document.querySelector('.orbit-three'),
+      document.querySelector('.orbit-four'),
+      document.querySelector('.orbit-five'),
+      document.querySelector('.orbit-six'),
+      document.querySelector('.orbit-seven'),
+      document.querySelector('.orbit-eight'),
+      document.querySelector('.orbit-nine'),
+      document.querySelector('.orbit-ten')
+    ]
+  };
+
+  let scheduled = false;
+
+  const animateMathDecor = () => {
+    const y = window.scrollY;
+    const amplitude = 80;
+    const period = amplitude * 2;
+    const verticalDrift = y * 0.38;
+
+    artLayer.leftSine.style.transform = `translate3d(0, ${-verticalDrift}px, 0)`;
+    artLayer.rightSine.style.transform = `translate3d(0, ${-verticalDrift}px, 0) scaleX(-1)`;
+
+    const anchors = [
+      { side: 'left', baseY: 8, r: 75 },
+      { side: 'left', baseY: 18, r: 61 },
+      { side: 'left', baseY: 30, r: 52 },
+      { side: 'left', baseY: 44, r: 43 },
+      { side: 'left', baseY: 60, r: 37 },
+      { side: 'right', baseY: 12, r: 33 },
+      { side: 'right', baseY: 26, r: 29 },
+      { side: 'right', baseY: 40, r: 25 },
+      { side: 'right', baseY: 56, r: 21 },
+      { side: 'right', baseY: 72, r: 18 }
+    ];
+
+    anchors.forEach((anchor, i) => {
+      const circle = artLayer.circles[i];
+      if (!circle) return;
+
+      const localY = (y * 0.55) + anchor.baseY * 10;
+      const waveOffset = Math.sin((2 * Math.PI * localY) / period) * amplitude;
+      const sideSign = anchor.side === 'left' ? 1 : -1;
+      const railX = anchor.side === 'left' ? 42 : window.innerWidth - 42;
+      const tangentX = railX + (sideSign * waveOffset);
+      const centerX = tangentX + (sideSign * anchor.r);
+      const centerY = anchor.baseY + (localY * 0.22);
+
+      circle.style.transform = `translate3d(${centerX - anchor.r}px, ${centerY - anchor.r}px, 0)`;
+    });
+
+    scheduled = false;
+  };
+
+  window.addEventListener('scroll', () => {
+    if (!scheduled) {
+      requestAnimationFrame(animateMathDecor);
+      scheduled = true;
+    }
+  }, { passive: true });
+
+  animateMathDecor();
+
 
     setInterval(() => {
     idx = (idx + 1) % subtitleStyles.length;


### PR DESCRIPTION
### Motivation
- Add subtle, math-inspired decorative art that animates with page scroll to give the layout more depth and personality.
- Keep decorations non-interactive and visually layered behind content so they don't interfere with existing UI or links.
- Respect user preferences by disabling motion when `prefers-reduced-motion` is set.

### Description
- Introduced a new decoration layer via the `math-scroll-art` container and multiple decorative elements (`.sine-track`, `.orbit-circle`) injected into the page body with `aria-hidden="true"`.
- Added comprehensive CSS for the decorations, including `background-image` sine tracks, orbit circle sizing, z-index management, and a `@media (prefers-reduced-motion: reduce)` rule to suppress transforms.
- Implemented `animateMathDecor` in the page script which computes positions for the orbit circles and sine tracks based on `window.scrollY`, using `requestAnimationFrame` for smooth updates and rate-limiting via a `scheduled` flag.
- Tweaked existing styles by reducing the noise overlay opacity and adjusting z-indexes (e.g., container and overlay) to ensure proper visual stacking.

### Testing
- No automated tests are configured for this change, so no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11fbeb6f54832cad6b055305280dac)