### PR TITLE
Add scroll-synced decorative math artwork (sine tracks + orbiting circles)

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,14 +43,69 @@
       inset: 0;
       /*  *Feel free to swap this data-URI for your own noise texture*  */
       background-image: url('data:image/svg+xml;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4/5+hHgAHggJ/qTJSwwAAAABJRU5ErkJggg==');
-      opacity: .15;
+      opacity: .12;
       pointer-events: none;
+      z-index: 3;
+    }
+
+
+    .math-scroll-art {
+      position: fixed;
+      inset: 0;
+      pointer-events: none;
+      z-index: 2;
+      overflow: hidden;
     }
 
     .container {
+      position: relative;
+      z-index: 4;
       max-width: 1200px;
       margin: 0 auto;
       padding: 2rem;
+    }
+
+    .sine-track {
+      position: absolute;
+      width: clamp(170px, 20vw, 300px);
+      height: var(--decor-height, 100%);
+      top: 0;
+      opacity: .98;
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 260 640'%3E%3Cpath d='M130 0 C50 40 50 120 130 160 C210 200 210 280 130 320 C50 360 50 440 130 480 C210 520 210 600 130 640' stroke='%23C70039' stroke-width='5' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
+      background-repeat: repeat-y;
+      background-size: 100% 320px;
+      filter: drop-shadow(0 0 10px rgba(199, 0, 57, .5));
+      will-change: transform;
+    }
+
+    .sine-left { left: -46px; }
+
+    .sine-right {
+      right: -46px;
+      transform: scaleX(-1);
+      opacity: .82;
+    }
+
+    .orbit-circle {
+      position: absolute;
+      border-radius: 50%;
+      border: 3px solid rgba(255, 230, 230, .95);
+      box-shadow: 0 0 0 5px rgba(199, 0, 57, .08), 0 0 18px rgba(199, 0, 57, .3);
+      opacity: .92;
+      will-change: transform;
+    }
+
+    .orbit-one { width: 130px; height: 130px; }
+    .orbit-two { width: 98px; height: 98px; }
+    .orbit-three { width: 70px; height: 70px; }
+    .orbit-four { width: 130px; height: 130px; }
+    .orbit-five { width: 98px; height: 98px; }
+    .orbit-six { width: 70px; height: 70px; }
+
+    @media (prefers-reduced-motion: reduce) {
+      .sine-track, .orbit-circle {
+        transform: none !important;
+      }
     }
 
     /*  ░░░  HERO  ░░░  */
@@ -211,6 +266,16 @@
   </style>
 </head>
 <body>
+  <div class="math-scroll-art" aria-hidden="true">
+    <div class="sine-track sine-left"></div>
+    <div class="sine-track sine-right"></div>
+    <div class="orbit-circle orbit-one"></div>
+    <div class="orbit-circle orbit-two"></div>
+    <div class="orbit-circle orbit-three"></div>
+    <div class="orbit-circle orbit-four"></div>
+    <div class="orbit-circle orbit-five"></div>
+    <div class="orbit-circle orbit-six"></div>
+  </div>
   <div id="cursor-circle"></div>
   <div class="container">
 
@@ -344,6 +409,80 @@
   };
 
   applyStyle(subtitleStyles[idx]);
+
+  const artLayer = {
+    leftSine: document.querySelector('.sine-left'),
+    rightSine: document.querySelector('.sine-right'),
+    circles: [
+      document.querySelector('.orbit-one'),
+      document.querySelector('.orbit-two'),
+      document.querySelector('.orbit-three'),
+      document.querySelector('.orbit-four'),
+      document.querySelector('.orbit-five'),
+      document.querySelector('.orbit-six')
+    ]
+  };
+
+  let scheduled = false;
+
+  const animateMathDecor = () => {
+    const y = window.scrollY;
+    const doc = document.documentElement;
+    const totalHeight = Math.max(doc.scrollHeight, document.body.scrollHeight);
+    document.documentElement.style.setProperty('--decor-height', `${totalHeight}px`);
+
+    const amplitude = 80;
+    const period = amplitude * 2;
+    const verticalDrift = y * 0.38;
+
+    artLayer.leftSine.style.transform = `translate3d(0, ${-verticalDrift}px, 0)`;
+    artLayer.rightSine.style.transform = `translate3d(0, ${-verticalDrift}px, 0) scaleX(-1)`;
+
+    const leftAnchors = [
+      { baseY: 16, r: 65 },
+      { baseY: 42, r: 49 },
+      { baseY: 70, r: 35 }
+    ];
+
+    const rightAnchors = leftAnchors.map(a => ({
+      baseY: 100 - a.baseY,
+      r: a.r
+    }));
+
+    const allAnchors = [
+      ...leftAnchors.map(a => ({ ...a, side: 'left' })),
+      ...rightAnchors.map(a => ({ ...a, side: 'right' }))
+    ];
+
+    allAnchors.forEach((anchor, i) => {
+      const circle = artLayer.circles[i];
+      if (!circle) return;
+
+      const localY = (y * 0.45) + (anchor.baseY / 100) * totalHeight;
+      const waveOffset = Math.sin((2 * Math.PI * localY) / period) * amplitude;
+      const sideSign = anchor.side === 'left' ? 1 : -1;
+      const railX = anchor.side === 'left' ? 42 : window.innerWidth - 42;
+
+      // Tangency: point on sine curve equals one perimeter point of circle
+      const tangentX = railX + (sideSign * waveOffset);
+      const centerX = tangentX + (sideSign * anchor.r);
+      const centerY = localY;
+
+      circle.style.transform = `translate3d(${centerX - anchor.r}px, ${centerY - anchor.r}px, 0)`;
+    });
+
+    scheduled = false;
+  };
+
+  window.addEventListener('scroll', () => {
+    if (!scheduled) {
+      requestAnimationFrame(animateMathDecor);
+      scheduled = true;
+    }
+  }, { passive: true });
+
+  animateMathDecor();
+
 
     setInterval(() => {
     idx = (idx + 1) % subtitleStyles.length;


### PR DESCRIPTION
### Motivation

- Introduce a subtle, math-inspired decorative layer that scrolls with the page to add depth and visual interest around the hero section. 
- Keep animations performant and accessible by using `requestAnimationFrame` and honoring `prefers-reduced-motion`. 
- Ensure the decorative layer sits behind content while not interfering with pointer events by using proper `z-index` and `pointer-events` settings.

### Description

- Added a new decorative DOM block `div.math-scroll-art` with two `sine-track` elements and six `orbit-circle` elements inserted into the top of the `body`. 
- Added styles for `.math-scroll-art`, `.sine-track`, and `.orbit-circle`, updated `body::before` opacity and z-index, and set `position`/`z-index` for `.container` so the decoration stays behind interactive content. 
- Implemented inline SVG background for the sine tracks, sizing, drop-shadow, and responsive width with `clamp()` as well as sizing classes for orbit circles. 
- Added JavaScript that selects the art elements (`artLayer`), computes a scroll-driven layout using `requestAnimationFrame`, updates `--decor-height` and transforms for the sine tracks and circles, and attaches a passive `scroll` listener with motion reduction support.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11fbeb6f54832cad6b055305280dac)