### PR TITLE
Add scroll-driven math-inspired decorative art layer (sine tracks & orbiting circles)

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,14 +43,69 @@
       inset: 0;
       /*  *Feel free to swap this data-URI for your own noise texture*  */
       background-image: url('data:image/svg+xml;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4/5+hHgAHggJ/qTJSwwAAAABJRU5ErkJggg==');
-      opacity: .15;
+      opacity: .12;
       pointer-events: none;
+      z-index: 3;
+    }
+
+
+    .math-scroll-art {
+      position: fixed;
+      inset: 0;
+      pointer-events: none;
+      z-index: 2;
+      overflow: hidden;
     }
 
     .container {
+      position: relative;
+      z-index: 4;
       max-width: 1200px;
       margin: 0 auto;
       padding: 2rem;
+    }
+
+    .sine-track {
+      position: absolute;
+      width: clamp(170px, 20vw, 300px);
+      height: var(--decor-height, 100%);
+      top: 0;
+      opacity: .98;
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 260 640'%3E%3Cpath d='M130 0 C50 40 50 120 130 160 C210 200 210 280 130 320 C50 360 50 440 130 480 C210 520 210 600 130 640' stroke='%23C70039' stroke-width='8' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
+      background-repeat: repeat-y;
+      background-size: 100% 320px;
+      filter: drop-shadow(0 0 10px rgba(199, 0, 57, .5));
+      will-change: transform;
+    }
+
+    .sine-left { left: -46px; }
+
+    .sine-right {
+      right: -46px;
+      transform: scaleX(-1);
+      opacity: .82;
+    }
+
+    .orbit-circle {
+      position: absolute;
+      border-radius: 50%;
+      border: 3px solid rgba(255, 230, 230, .95);
+      box-shadow: 0 0 0 5px rgba(199, 0, 57, .08), 0 0 18px rgba(199, 0, 57, .3);
+      opacity: .92;
+      will-change: transform;
+    }
+
+    .orbit-one { width: 130px; height: 130px; }
+    .orbit-two { width: 98px; height: 98px; }
+    .orbit-three { width: 70px; height: 70px; }
+    .orbit-four { width: 130px; height: 130px; }
+    .orbit-five { width: 98px; height: 98px; }
+    .orbit-six { width: 70px; height: 70px; }
+
+    @media (prefers-reduced-motion: reduce) {
+      .sine-track, .orbit-circle {
+        transform: none !important;
+      }
     }
 
     /*  ░░░  HERO  ░░░  */
@@ -211,6 +266,16 @@
   </style>
 </head>
 <body>
+  <div class="math-scroll-art" aria-hidden="true">
+    <div class="sine-track sine-left"></div>
+    <div class="sine-track sine-right"></div>
+    <div class="orbit-circle orbit-one"></div>
+    <div class="orbit-circle orbit-two"></div>
+    <div class="orbit-circle orbit-three"></div>
+    <div class="orbit-circle orbit-four"></div>
+    <div class="orbit-circle orbit-five"></div>
+    <div class="orbit-circle orbit-six"></div>
+  </div>
   <div id="cursor-circle"></div>
   <div class="container">
 
@@ -344,6 +409,81 @@
   };
 
   applyStyle(subtitleStyles[idx]);
+
+  const artLayer = {
+    leftSine: document.querySelector('.sine-left'),
+    rightSine: document.querySelector('.sine-right'),
+    circles: [
+      document.querySelector('.orbit-one'),
+      document.querySelector('.orbit-two'),
+      document.querySelector('.orbit-three'),
+      document.querySelector('.orbit-four'),
+      document.querySelector('.orbit-five'),
+      document.querySelector('.orbit-six')
+    ]
+  };
+
+  let scheduled = false;
+
+  const animateMathDecor = () => {
+    const y = window.scrollY;
+    const doc = document.documentElement;
+    const totalHeight = Math.max(doc.scrollHeight, document.body.scrollHeight);
+    document.documentElement.style.setProperty('--decor-height', `${totalHeight}px`);
+
+    const amplitude = 80;
+    const period = amplitude * 2;
+    const verticalDrift = y * 0.38;
+
+    artLayer.leftSine.style.transform = `translate3d(0, ${-verticalDrift}px, 0)`;
+    artLayer.rightSine.style.transform = `translate3d(0, ${-verticalDrift}px, 0) scaleX(-1)`;
+
+    const leftAnchors = [
+      { baseYvh: 18, r: 65 },
+      { baseYvh: 42, r: 49 },
+      { baseYvh: 68, r: 35 }
+    ];
+
+    const rightAnchors = leftAnchors.map(a => ({
+      baseYvh: a.baseYvh,
+      r: a.r
+    }));
+
+    const allAnchors = [
+      ...leftAnchors.map(a => ({ ...a, side: 'left' })),
+      ...rightAnchors.map(a => ({ ...a, side: 'right' }))
+    ];
+
+    allAnchors.forEach((anchor, i) => {
+      const circle = artLayer.circles[i];
+      if (!circle) return;
+
+      const localY = (anchor.baseYvh / 100) * window.innerHeight + (y * 0.28);
+      const waveOffset = Math.sin((2 * Math.PI * localY) / period) * amplitude;
+      const sideSign = anchor.side === 'left' ? 1 : -1;
+      const railX = anchor.side === 'left' ? 42 : window.innerWidth - 42;
+
+      // Tangency: point on sine curve equals one perimeter point of circle
+      const tangentX = railX + (sideSign * waveOffset);
+      const centerX = tangentX + (sideSign * anchor.r);
+      const wrappedY = ((localY % (window.innerHeight + 220)) + (window.innerHeight + 220)) % (window.innerHeight + 220) - 110;
+      const centerY = wrappedY;
+
+      circle.style.transform = `translate3d(${centerX - anchor.r}px, ${centerY - anchor.r}px, 0)`;
+    });
+
+    scheduled = false;
+  };
+
+  window.addEventListener('scroll', () => {
+    if (!scheduled) {
+      requestAnimationFrame(animateMathDecor);
+      scheduled = true;
+    }
+  }, { passive: true });
+
+  animateMathDecor();
+
 
     setInterval(() => {
     idx = (idx + 1) % subtitleStyles.length;


### PR DESCRIPTION
### Motivation
- Add a decorative, math-inspired visual layer that animates with page scroll to give the page a dynamic, science/geometry-themed aesthetic. 
- Improve stacking and layering so the decorative art sits behind content but above the subtle noise overlay. 
- Keep animations performant and respectful of user preferences by using `requestAnimationFrame` and honoring `prefers-reduced-motion`. 

### Description
- Introduced a new `.math-scroll-art` HTML container containing two sine-track rails and six `.orbit-circle` elements to form the decorative layer. 
- Added CSS for `body::before` opacity/z-index adjustments, `.math-scroll-art`, `.sine-track`, and `.orbit-circle` styling including a data-URI SVG rail, drop shadows, sizing, and a `@media (prefers-reduced-motion: reduce)` rule. 
- Added JS that queries the art elements into `artLayer`, computes scroll-driven positions in `animateMathDecor`, updates `--decor-height`, and schedules updates on `scroll` via `requestAnimationFrame` with a passive listener; the animation is invoked once on load. 
- Kept existing subtitle font-rotation logic intact and ensured new layout stacking by setting `z-index` on relevant containers (`body::before`, `.math-scroll-art`, `.container`). 

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11fbeb6f54832cad6b055305280dac)